### PR TITLE
ci: simplify workflows, use action-based github pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: Deploy documentation site to Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          tools: composer:v2, phpdoc
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build documentation
+        run: composer docs
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs/build
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  PHP_LATEST: 8.2
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -41,44 +38,3 @@ jobs:
       run: composer install --prefer-dist --no-progress
     - name: Run test suite
       run: composer test
-
-  docs:
-    runs-on: ubuntu-latest
-    needs: build
-    if: ${{ github.event_name == 'push' }}
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ env.PHP_LATEST }}
-        tools: composer:v2, phpdoc
-    - name: Build documentation
-      run: composer docs
-    - name: Deploy documentation
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs/build
-
-  ci-success-pr:
-    runs-on: ubuntu-latest
-    name: ci-success (PR)
-    if: ${{ success() && github.event_name == 'pull_request' }}
-    needs:
-      - build
-    steps:
-      - name: ✅ CI succeeded
-        run: exit 0
-
-  ci-success:
-    runs-on: ubuntu-latest
-    name: ci-success
-    if: ${{ success() && github.event_name == 'push' }}
-    needs:
-      - build
-      - docs
-    steps:
-      - name: ✅ CI succeeded
-        run: exit 0


### PR DESCRIPTION
- switch from branch-based to action-based github pages
- remove ci-success/ci-success-pr jobs from main workflow